### PR TITLE
Bugfix: The intended ZEH/v1 compatability was not compatible 😱

### DIFF
--- a/feedapi/fixture_test.go
+++ b/feedapi/fixture_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+
+	"github.com/sirupsen/logrus"
 )
 
 var logger *logrus.Logger
@@ -36,6 +37,10 @@ func Server(publisher EventPublisher) *httptest.Server {
 	}
 
 	return httptest.NewServer(http.HandlerFunc(routingHandler))
+}
+
+type TestFeedAPI struct {
+	partitions map[int][]TestEvent
 }
 
 func NewTestFeedAPI() *TestFeedAPI {

--- a/feedapi/receiver_v1.go
+++ b/feedapi/receiver_v1.go
@@ -1,0 +1,44 @@
+package feedapi
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// NDJSONEventSerializerV1 implements EventReceiver by emitting Newline-Delimited-JSON to a writer.
+// It adds a "partition" key to the respose structs, as used by the version 1 (ZeroEventHub) server
+type NDJSONEventSerializerV1 struct {
+	encoder     *json.Encoder
+	writer      io.Writer
+	partitionID int
+}
+
+func NewNDJSONEventSerializerV1(partitionID int, writer io.Writer) *NDJSONEventSerializerV1 {
+	return &NDJSONEventSerializerV1{
+		encoder:     json.NewEncoder(writer),
+		writer:      writer,
+		partitionID: partitionID,
+	}
+}
+
+func (s NDJSONEventSerializerV1) writeNdJsonLine(item interface{}) error {
+	return s.encoder.Encode(item)
+}
+
+func (s NDJSONEventSerializerV1) Checkpoint(cursor string) error {
+	type CursorMessage struct {
+		Cursor    string `json:"cursor"`
+		Partition int    `json:"partition"`
+	}
+	return s.writeNdJsonLine(CursorMessage{Cursor: cursor, Partition: s.partitionID})
+}
+
+func (s NDJSONEventSerializerV1) Event(data json.RawMessage) error {
+	type EventMessage struct {
+		Data      json.RawMessage `json:"data"`
+		Partition int             `json:"partition"`
+	}
+	return s.writeNdJsonLine(EventMessage{Data: data, Partition: s.partitionID})
+}
+
+var _ EventReceiver = &NDJSONEventSerializerV1{}

--- a/feedapi/server_v1.go
+++ b/feedapi/server_v1.go
@@ -57,7 +57,7 @@ func (h HTTPHandlers) ZeroEventHubV1Handler(writer http.ResponseWriter, request 
 		WithField("PageSizeHint", pageSizeHint).
 		WithField("Headers", headers)
 	fields.Info()
-	serializer := NewNDJSONEventSerializer(writer)
+	serializer := NewNDJSONEventSerializerV1(partitionID, writer)
 	err := h.eventPublisher.FetchEvents(request.Context(), "", partitionID, cursor, serializer, Options{
 		PageSizeHint: pageSizeHint,
 	})


### PR DESCRIPTION
Made a mistake changing this library from ZEH to FeedAPI; dropped the `partition:` in the response not only in the updated API response but only in the "backwards compatible" V1 response -- making it non-backwards-compatible really.

Although no real world clients are likely to have been hit, this hits a test suite of a service currently being migrated.