### PR TITLE
Add optional support for client side filtering on event types

### DIFF
--- a/feedapi/client.go
+++ b/feedapi/client.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 )
 
 // Client struct is a generic-based client-side implementation of the EventFetcher interface.
@@ -155,6 +156,9 @@ func (c Client) FetchEvents(ctx context.Context, token string, partitionID int, 
 	q.Add("cursor", cursor)
 	if options.PageSizeHint != DefaultPageSize {
 		q.Add("pagesizehint", fmt.Sprintf("%d", options.PageSizeHint))
+	}
+	if options.EventTypes != nil {
+		q.Add("event-types", strings.Join(options.EventTypes, ";"))
 	}
 
 	req.URL.RawQuery = q.Encode()

--- a/feedapi/interfaces.go
+++ b/feedapi/interfaces.go
@@ -33,6 +33,7 @@ type EventReceiver interface {
 
 type Options struct {
 	PageSizeHint int
+	EventTypes   []string
 }
 
 // EventFetcher is a generic-based interface providing a contract for fetching events: both for the server side and

--- a/feedapi/v1_test.go
+++ b/feedapi/v1_test.go
@@ -29,6 +29,7 @@ type TestEvent struct {
 	ID      string
 	Version int
 	Cursor  int
+	Type    string
 }
 
 func TestAPI_V1(t *testing.T) {


### PR DESCRIPTION
Example

my-feed-query?event-types=payment-cancelled;payment-captured